### PR TITLE
Disabled overwritten belongsTo and belongsToMany.

### DIFF
--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -205,15 +205,15 @@ class BaseModel extends Eloquent
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo or \App\Extensions\Database\EmptyRelation
 	 * @author Patrick Reichel
 	 */
-    public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null) {
+    /* public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null) { */
 
-		if ($this->_relationAvailable($related)) {
-			return parent::belongsTo($related, $foreignKey, $otherKey, $relation);
-		}
-		else {
-			return new EmptyRelation();
-		}
-	}
+		/* if ($this->_relationAvailable($related)) { */
+			/* return parent::belongsTo($related, $foreignKey, $otherKey, $relation); */
+		/* } */
+		/* else { */
+			/* return new EmptyRelation(); */
+		/* } */
+	/* } */
 
 
 	/**
@@ -227,15 +227,15 @@ class BaseModel extends Eloquent
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany or \App\Extensions\Database\EmptyRelation
 	 * @author Patrick Reichel
 	 */
-    public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $relation = null) {
+    /* public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $relation = null) { */
 
-		if ($this->_relationAvailable($related)) {
-			return parent::belongsToMany($related, $table, $foreignKey, $otherKey, $relation);
-		}
-		else {
-			return new EmptyRelation();
-		}
-	}
+		/* if ($this->_relationAvailable($related)) { */
+			/* return parent::belongsToMany($related, $table, $foreignKey, $otherKey, $relation); */
+		/* } */
+		/* else { */
+			/* return new EmptyRelation(); */
+		/* } */
+	/* } */
 
 
 	/**


### PR DESCRIPTION
Strange problems when using this methods:

- Empty contract returned as relation in EnviaOrder/edit and
  EnviaContract/edit
- Contract/edit: Items are listet but with “Missing product“
  information
- The problem is caused by calling parent::belongsTo() in
  BaseModel::belongsTo() – which is strange and needs further
  examination.

So ATM using a NMSPrime instance with disabled BillingBase will cause
crashes.