### PR TITLE
Bugfix/delete fails on some models

### DIFF
--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -22,6 +22,9 @@ class BaseModel extends Eloquent
 	// use to enable force delete for inherit models
 	protected $force_delete = 0;
 
+	// flag showing if children also shall be deleted on Model::delete()
+	protected $delete_children = True;
+
 	public $voip_enabled;
 	public $billing_enabled;
 	protected $fillable = array();
@@ -735,9 +738,25 @@ class BaseModel extends Eloquent
 	 */
 	public function get_all_children()
 	{
-		$relations = [];
-		// exceptions
-		$exceptions = ['configfile_id', 'salesman_id', 'costcenter_id', 'company_id', 'sepaaccount_id', 'product_id'/*, 'mibfile_id', 'oid_id'*/];
+		$relations = [
+			'1:n' => [],
+			'n:m' => []
+		];
+		// exceptions – the children (=their database ID fields) that never should be deleted
+		$exceptions = [
+			'company_id',
+			'configfile_id',
+			'costcenter_id',
+			'country_id',	// not used yet
+			//'mibfile_id',
+			//'oid_id',
+			'product_id',
+			'qos_id',
+			'salesman_id',
+			'sepaaccount_id',
+			'voip_id',
+		];
+
 
 		// this is the variable that holds table names in $table returned by DB::select('SHOW TABLES')
 		// named dynamically containing the database name
@@ -755,18 +774,44 @@ class BaseModel extends Eloquent
 					if (in_array($column, $exceptions))
 						continue;
 					// get all objects with $column
-					foreach (DB::select('SELECT id FROM '.$table->$tables_var_name.' WHERE '.$column.'='.$this->id) as $child)
+					$query = 'SELECT * FROM '.$table->$tables_var_name.' WHERE '.$column.'='.$this->id;
+					echo $query.'<br>';
+					foreach (DB::select($query) as $child)
 					{
 						$class_child_name = $this->_guess_model_name ($table->$tables_var_name);
-						$class = new $class_child_name;
-
-						array_push($relations, $class->find($child->id));
+						// check if we got a model name
+						if ($class_child_name) {
+							// yes! 1:n relation
+							$class = new $class_child_name;
+							$rel = $class->find($child->id);
+							if (!is_null($rel)) {
+								array_push($relations['1:n'], $rel);
+							}
+						}
+						else {
+							// seems to be a n:m relation
+							$parts = explode('_', $table->$tables_var_name);
+							foreach ($parts as $part) {
+								$class_child_name = $this->_guess_model_name($part);
+								if ($class_child_name == get_class($this)) {
+									continue;
+								}
+								else {
+									$class = new $class_child_name;
+									$id_col = $part.'_id';
+									$rel = $class->find($child->{$id_col});
+									if (!is_null($rel)) {
+										array_push($relations['n:m'], $rel);
+									}
+								}
+							}
+						}
 					}
 				}
 			}
 		}
 
-		return array_filter ($relations);
+		return $relations;
 	}
 
 
@@ -784,22 +829,82 @@ class BaseModel extends Eloquent
 
 
 	/**
-	 *	Recursive delete of all children objects
+	 * Recursive delete of all children objects
 	 *
-	 *	@author Torsten Schmidt
+	 * @author Torsten Schmidt
 	 *
-	 *	@return bool
+	 * @return bool
 	 *
-	 *  @todo return state on success, should also take care of deleted children
+	 * @todo return state on success, should also take care of deleted children
 	 */
 	public function delete()
 	{
-		// dd( $this->get_all_children() );
-		foreach ($this->get_all_children() as $child)
-			$child->delete();
+		// check from where the deletion request has been triggered and set the correct var to show information
+		$prev = explode('?', \URL::previous())[0];
+		$prev = \Str::lower($prev);
+
+		if ($this->delete_children) {
+			$children = $this->get_all_children();
+			// find and delete all children
+
+			// deletion of 1:n related children is straight forward
+			foreach ($children['1:n'] as $child) {
+
+				// if one direct or indirect child cannot be deleted:
+				// do not delete anything
+				if (!$child->delete()) {
+					$msg = "Cannot delete ".$this->get_model_name()." $this->id because ".$child->get_model_name()." $child->id cannot be deleted";
+					if (\Str::endsWith($prev, 'edit')) {
+						\Session::push('tmp_error_above_relations', $msg);
+					}
+					else {
+						\Session::push('tmp_error_above_index_list', $msg);
+					}
+					return false;
+				}
+			}
+
+			// in n:m relations we have to detach instead of deleting if
+			// child is related to others, too
+			// this should be handled in class methods because BaseModel cannot know the possible problems
+			foreach ($children['n:m'] as $child) {
+				$delete_method = 'deleteNtoM'.$child->get_model_name();
+				if (!$this->{$delete_method}($child)) {
+					$msg = "Cannot delete ".$this->get_model_name()." $this->id because of existing n:m relation with ".$child->get_model_name()." $child->id.";
+					if (\Str::endsWith($prev, 'edit')) {
+						\Session::push('tmp_error_above_relations', $msg);
+					}
+					else {
+						\Session::push('tmp_error_above_index_list', $msg);
+					}
+					return false;
+				}
+			}
+
+		}
 
 		// always return this value (also in your derived classes!)
-		return $this->_delete();
+		$deleted = $this->_delete();
+		if (!$deleted) {
+			$msg = "Could not delete ".$this->get_model_name()." $this->id";
+			if (\Str::endsWith($prev, 'edit')) {
+				\Session::push('tmp_error_above_relations', $msg);
+			}
+			else {
+				\Session::push('tmp_error_above_index_list', $msg);
+			}
+		}
+		else {
+			$msg = "Deleted ".$this->get_model_name()." $this->id";
+			if (\Str::endsWith($prev, 'edit')) {
+				\Session::push('tmp_success_above_relations', $msg);
+			}
+			else {
+				\Session::push('tmp_success_above_index_list', $msg);
+			}
+		}
+
+		return $deleted;
 	}
 
 

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -35,6 +35,10 @@ class BaseModel extends Eloquent
 	// set this variable in model index_list() to true if it shall not be deletable on index page
 	public $index_delete_disabled = false;
 
+	// Add Comment here. ..
+	protected $guarded = ['id'];
+
+
 	/**
 	 * Constructor.
 	 * Used to set some helper variables.
@@ -55,8 +59,17 @@ class BaseModel extends Eloquent
 	}
 
 
-	// Add Comment here. ..
-	protected $guarded = ['id'];
+	/**
+	 * Helper to get the model name.
+	 *
+	 * @author Patrick Reichel
+	 */
+	public function get_model_name() {
+
+		$model_name = get_class($this);
+		$model_name = explode('\\',$model_name);
+		return array_pop($model_name);
+	}
 
 
 	/**
@@ -916,9 +929,7 @@ class BaseObserver
 	{
 		$user = \Auth::user();
 
-		$model_name = get_class($model);
-		$model_name = explode('\\',$model_name);
-		$model_name = array_pop($model_name);
+		$model_name = $model->get_model_name();
 
 		$text = '';
 

--- a/modules/ProvBase/Entities/Contract.php
+++ b/modules/ProvBase/Entities/Contract.php
@@ -124,17 +124,20 @@ class Contract extends \BaseModel {
 			$ret['Billing']['SepaMandate']['relation']  = $this->sepamandates;
 			$ret['Billing']['Invoice']['class'] 	= 'Invoice';
 			$ret['Billing']['Invoice']['relation']  = $this->invoices;
-			$ret['Billing']['Invoice']['options']['hide_delete_button'] = 0;
-			$ret['Billing']['Invoice']['options']['hide_create_button'] = 0;
+			$ret['Billing']['Invoice']['options']['hide_delete_button'] = 1;
+			$ret['Billing']['Invoice']['options']['hide_create_button'] = 1;
 		}
 
 		if (\PPModule::is_active('provvoipenvia'))
 		{
 			$ret['envia TEL']['EnviaContract']['class'] = 'EnviaContract';
 			$ret['envia TEL']['EnviaContract']['relation'] = $this->enviacontracts;
+			$ret['envia TEL']['EnviaContract']['options']['hide_create_button'] = 1;
+			$ret['envia TEL']['EnviaContract']['options']['hide_delete_button'] = 1;
 
 			$ret['envia TEL']['EnviaOrder']['class'] = 'EnviaOrder';
 			$ret['envia TEL']['EnviaOrder']['relation'] = $this->_envia_orders;
+			$ret['envia TEL']['EnviaOrder']['options']['delete_button_text'] = 'Cancel order at envia TEL';
 
 			// TODO: auth - loading controller from model could be a security issue ?
 			$ret['envia TEL']['envia TEL API']['view']['view'] = 'provvoipenvia::ProvVoipEnvia.actions';

--- a/modules/ProvBase/Entities/Modem.php
+++ b/modules/ProvBase/Entities/Modem.php
@@ -216,9 +216,12 @@ class Modem extends \BaseModel {
 		{
 			$ret['dummy']['EnviaContract']['class'] = 'EnviaContract';
 			$ret['dummy']['EnviaContract']['relation'] = $this->enviacontracts;
+			$ret['dummy']['EnviaContract']['options']['hide_create_button'] = 1;
+			$ret['dummy']['EnviaContract']['options']['hide_delete_button'] = 1;
 
 			$ret['dummy']['EnviaOrder']['class'] = 'EnviaOrder';
 			$ret['dummy']['EnviaOrder']['relation'] = $this->_envia_orders;
+			$ret['envia TEL']['EnviaOrder']['options']['delete_button_text'] = 'Cancel order at envia TEL';
 
 			// TODO: auth - loading controller from model could be a security issue ?
 			$ret['dummy']['envia TEL API']['view']['view'] = 'provvoipenvia::ProvVoipEnvia.actions';

--- a/modules/ProvBase/Entities/Modem.php
+++ b/modules/ProvBase/Entities/Modem.php
@@ -619,7 +619,7 @@ class Modem extends \BaseModel {
 			}
 			else {
 				// Inform and log for all other exceptions
-				\Session::push('tmp_info_above_form', 'Unexpected exception: '.$e->getMessage());
+				\Session::push('tmp_error_above_form', 'Unexpected exception: '.$e->getMessage());
 				\Log::error("Unexpected exception restarting modem ".$this->id." (".$this->mac."): ".$e->getMessage()." => ".$e->getTraceAsString());
 				\Session::flash('error', '');
 			}
@@ -1027,38 +1027,6 @@ class Modem extends \BaseModel {
 		$this->observer_enabled = false;
 	}
 
-
-	/**
-	 * Before deleting a modem and all children we have to check some things
-	 *
-	 * @author Patrick Reichel
-	 */
-	public function delete() {
-
-		// deletion of modems with attached phonenumbers is not allowed with enabled envia TEL module
-		// prevent user from (recursive and implicite) deletion of phonenumbers before termination at envia TEL!!
-		// we have to check this here as using ModemObserver::deleting() with return false does not prevent the monster from deleting child model instances!
-		if (\PPModule::is_active('ProvVoipEnvia')) {
-			if ($this->has_phonenumbers_attached()) {
-
-				// check from where the deletion request has been triggered and set the correct var to show information
-				$prev = explode('?', \URL::previous())[0];
-				$prev = \Str::lower($prev);
-				$msg = "You are not allowed to delete a modem with attached phonenumbers!";
-				if (\Str::endsWith($prev, 'edit')) {
-					\Session::push('tmp_info_above_relations', $msg);
-				}
-				elseif (\Str::endsWith($prev, 'modem')) {
-					\Session::push('tmp_info_above_index_list', $msg);
-				}
-
-				return false;
-			}
-		}
-
-		// when arriving here: start the standard deletion procedure
-		return parent::delete();
-	}
 
 	/**
 	 * Calculates the great-circle distance between this and $modem, with

--- a/modules/ProvBase/Http/Controllers/ContractController.php
+++ b/modules/ProvBase/Http/Controllers/ContractController.php
@@ -155,7 +155,7 @@ class ContractController extends \BaseController {
 	 */
 	public function prepare_input($data)
 	{
-		$data['contract_start'] = isset($data['contract_start']) ? : date('Y-m-d');
+		$data['contract_start'] = $data['contract_start'] ? : date('Y-m-d');
 
 		$data = parent::prepare_input($data);
 

--- a/modules/ProvVoip/Entities/Mta.php
+++ b/modules/ProvVoip/Entities/Mta.php
@@ -368,7 +368,7 @@ _failed:
 			}
 			else {
 				// Inform and log for all other exceptions
-				\Session::push('tmp_info_above_form', 'Unexpected exception: '.$e->getMessage());
+				\Session::push('tmp_error_above_form', 'Unexpected exception: '.$e->getMessage());
 				\Log::error("Unexpected exception restarting MTA ".$this->id." (".$this->mac."): ".$e->getMessage()." => ".$e->getTraceAsString());
 				\Session::flash('error', '');
 			}

--- a/modules/ProvVoip/Entities/Phonenumber.php
+++ b/modules/ProvVoip/Entities/Phonenumber.php
@@ -667,38 +667,15 @@ class Phonenumber extends \BaseModel {
 
 
 	/**
-	 * Before deleting a modem and all children we have to check some things
+	 * Dummy method to match BaseModel::delete() requirements
+	 *
+	 * We do not have to delete envia TEL orders here – this is later done by cron job.
 	 *
 	 * @author Patrick Reichel
 	 */
-	public function delete() {
+	public function deleteNtoMEnviaOrder($envia_order) {
 
-		// deletion of modems with attached phonenumbers is not allowed with enabled envia TEL module
-		// prevent user from (recursive and implicite) deletion of phonenumbers before termination at envia TEL!!
-		// we have to check this here as using ModemObserver::deleting() with return false does not prevent the monster from deleting child model instances!
-		/* d(\URL::previous()); */
-		if (
-			(\PPModule::is_active('ProvVoipEnvia'))
-			&&
-			(!is_null($this->phonenumbermanagement))
-		) {
-
-			// check from where the deletion request has been triggered and set the correct var to show information
-			$prev = explode('?', \URL::previous())[0];
-			$prev = \Str::lower($prev);
-			$msg = "You are not allowed to delete a phonenumber with attached phonenumbermanagement!";
-			if (\Str::endsWith($prev, 'edit')) {
-				\Session::push('tmp_info_above_relations', $msg);
-			}
-			elseif (\Str::endsWith($prev, 'phonenumber')) {
-				\Session::push('tmp_info_above_index_list', $msg);
-			}
-
-			return false;
-		}
-
-		// when arriving here: start the standard deletion procedure
-		return parent::delete();
+		return $envia_order->delete();
 	}
 
 
@@ -792,7 +769,7 @@ class PhonenumberObserver
 		}
 
 		if (!$this->_phonenumber_reassignment_allowed($old_mta->modem, $new_mta->modem)) {
-			\Session::push('tmp_info_above_form', "Reassignement of phonenumber to MTA $new_mta->id not allowed");
+			\Session::push('tmp_error_above_form', "Reassignement of phonenumber to MTA $new_mta->id not allowed");
 			return False;
 		}
 

--- a/modules/ProvVoip/Http/Controllers/PhonebookEntryController.php
+++ b/modules/ProvVoip/Http/Controllers/PhonebookEntryController.php
@@ -27,7 +27,7 @@ class PhonebookEntryController extends \BaseController {
 			!(PhonenumberManagement::find(\Input::get('phonenumbermanagement_id')))
 		) {
 			$this->edit_view_save_button = false;
-			\Session::push('tmp_info_above_form', 'Cannot create phonebookentry – phonenumbermanagement ID missing or phonenumbermanagement not found');
+			\Session::push('tmp_error_above_form', 'Cannot create phonebookentry – phonenumbermanagement ID missing or phonenumbermanagement not found');
 		}
 
 		return parent::create();

--- a/modules/ProvVoip/Http/Controllers/PhonenumberManagementController.php
+++ b/modules/ProvVoip/Http/Controllers/PhonenumberManagementController.php
@@ -29,7 +29,7 @@ class PhonenumberManagementController extends \BaseController {
 			!(Phonenumber::find(\Input::get('phonenumber_id')))
 		) {
 			$this->edit_view_save_button = false;
-			\Session::push('tmp_info_above_form', 'Cannot create phonenumbermanagement – phonenumber ID missing or phonenumber not found');
+			\Session::push('tmp_error_above_form', 'Cannot create phonenumbermanagement – phonenumber ID missing or phonenumber not found');
 		}
 
 		return parent::create();

--- a/modules/ProvVoipEnvia/Entities/EnviaContract.php
+++ b/modules/ProvVoipEnvia/Entities/EnviaContract.php
@@ -262,12 +262,14 @@ class EnviaContract extends \BaseModel {
 		$relations['hints'] = array();
 		$relations['links'] = array();
 
-		if ($this->contract) {
-			$relations['hints']['Contract'] = ProvVoipEnviaHelpers::get_user_action_information_contract($this->contract);
+		if ($this->contract_id) {
+			$contract = Contract::withTrashed()->find($this->contract_id);
+			$relations['hints']['Contract'] = ProvVoipEnviaHelpers::get_user_action_information_contract($contract);
 		}
 
-		if ($this->modem) {
-			$relations['hints']['Modem'] = ProvVoipEnviaHelpers::get_user_action_information_modem($this->modem);
+		if ($this->modem_id) {
+			$modem = Modem::withTrashed()->find($this->modem_id);
+			$relations['hints']['Modem'] = ProvVoipEnviaHelpers::get_user_action_information_modem($modem);
 		}
 
 		$mgmts = $this->phonenumbermanagements;

--- a/modules/ProvVoipEnvia/Entities/EnviaContract.php
+++ b/modules/ProvVoipEnvia/Entities/EnviaContract.php
@@ -13,6 +13,9 @@ class EnviaContract extends \BaseModel {
 	// The associated SQL table for this Model
 	public $table = 'enviacontract';
 
+	// do not auto delete anything related to envia (can e.g. be contracts and modems)
+	protected $delete_children = False;
+
     protected $fillable = [];
 
 
@@ -283,6 +286,32 @@ class EnviaContract extends \BaseModel {
 
 		return $relations;
 
+	}
+
+
+	/**
+	 * We do not delete envia TEL contracts directly (e.g. on deleting a phonenumber).
+	 * This is later done using a cronjob that deletes all orphaned contracts.
+	 *
+	 * This method will return true so that related models can be deleted.
+	 *
+	 * @author Patrick Reichel
+	 */
+	public function delete() {
+
+		// check from where the deletion request has been triggered and set the correct var to show information
+		$prev = explode('?', \URL::previous())[0];
+		$prev = \Str::lower($prev);
+
+		$msg = "Deletion of envia TEL contracts will be done via cron job";
+		if (\Str::endsWith($prev, 'edit')) {
+			\Session::push('tmp_info_above_relations', $msg);
+		}
+		else {
+			\Session::push('tmp_info_above_index_list', $msg);
+		}
+
+		return True;
 	}
 
 }

--- a/modules/ProvVoipEnvia/Entities/EnviaOrder.php
+++ b/modules/ProvVoipEnvia/Entities/EnviaOrder.php
@@ -871,16 +871,18 @@ class EnviaOrder extends \BaseModel {
 		$user_actions['links'] = array();
 
 
-		$contract = $this->contract;
-		$user_actions['hints']['Contract (= envia TEL  Customer)'] = ProvVoipEnviaHelpers::get_user_action_information_contract($contract);
+		if ($this->contract_id) {
+			$contract = Contract::withTrashed()->find($this->contract_id);
+			$user_actions['hints']['Contract (= envia TEL  Customer)'] = ProvVoipEnviaHelpers::get_user_action_information_contract($contract);
+		}
 
 		$items = $contract->items;
 		if ($items) {
 			$user_actions['hints']['Items (Internet and VoIP only)'] = ProvVoipEnviaHelpers::get_user_action_information_items($items);
 		};
 
-		$modem = $this->modem;
-		if ($modem) {
+		if ($this->modem_id) {
+			$modem = Modem::withTrashed()->find($this->modem_id);
 			$user_actions['hints']['Modem (can hold multiple envia TEL contracts)'] = ProvVoipEnviaHelpers::get_user_action_information_modem($modem);
 		};
 

--- a/modules/ProvVoipEnvia/Entities/ProvVoipEnviaHelpers.php
+++ b/modules/ProvVoipEnvia/Entities/ProvVoipEnviaHelpers.php
@@ -84,7 +84,12 @@ class ProvVoipEnviaHelpers {
 
 		$row= array();
 
-		array_push($row, '<a href="'.\URL::route("Contract.edit", array("Contract" => $contract->id)).'">'.$contract->number.'</a>');
+		if (is_null($contract->deleted_at)) {
+			array_push($row, '<a href="'.\URL::route("Contract.edit", array("Contract" => $contract->id)).'">'.$contract->number.'</a>');
+		}
+		else {
+			array_push($row, "<s>$contract->number</s>");
+		}
 
 		$tmp_address = "";
 		$tmp_address .= (boolval($contract->company) ? $contract->company.",<br>" : "");
@@ -187,7 +192,12 @@ class ProvVoipEnviaHelpers {
 
 		$row = array();
 
-		array_push($row, '<a href="'.\URL::route("Modem.edit", array("Modem" => $modem->id)).'">'.$modem->mac.'</a>');
+		if (is_null($modem->deleted_at)) {
+			array_push($row, '<a href="'.\URL::route("Modem.edit", array("Modem" => $modem->id)).'">'.$modem->mac.'</a>');
+		}
+		else {
+			array_push($row, "<s>$modem->mac</s>");
+		}
 		array_push($row, $modem->hostname);
 
 		$tmp_address = "";

--- a/resources/views/Generic/above_infos.blade.php
+++ b/resources/views/Generic/above_infos.blade.php
@@ -1,0 +1,58 @@
+<?php $tmp_msg_above_keys = [
+	'tmp_success_above_form',
+	'tmp_info_above_form',
+	'tmp_error_above_form',
+	'tmp_success_above_index_list',
+	'tmp_info_above_index_list',
+	'tmp_error_above_index_list',
+	'tmp_success_above_relations',
+	'tmp_info_above_relations',
+	'tmp_error_above_relations',
+	];
+
+$tmp_msg_above = [];
+foreach ($tmp_msg_above_keys as $tmp_msg_above_key) {
+	if ((Session::has($tmp_msg_above_key)) && (Str::endswith($tmp_msg_above_key, $blade_type))) {
+		$tmp_msg_above[$tmp_msg_above_key] = Session::get($tmp_msg_above_key);
+	}
+}
+?>
+
+@foreach ($tmp_msg_above as $tmp_msg_above_key => $tmp_msg_above_msg)
+	@DivOpen(12)
+	<?php
+
+		// for better handling: transform strings to array (containing one element)
+		if (is_string($tmp_msg_above_msg)) {
+			$tmp_msg_above_msg = [$tmp_msg_above_msg];
+		};
+		$tmp_msg_above_msg = array_unique($tmp_msg_above_msg);
+
+		// set color depending on message type
+		$tmp_type = explode('_', $tmp_msg_above_key)[1];
+		if ($tmp_type == 'info') {
+			$tmp_color = '#aaaaff';
+		}
+		elseif ($tmp_type == 'success') {
+			$tmp_color = '#aaffaa';
+		}
+		elseif ($tmp_type == 'error') {
+			$tmp_color = '#ffaaaa';
+		}
+		else {
+			$tmp_color = '#aaaaaa';
+		}
+		$tmp_style = "font-weight: bold; padding-top: 0px; padding-left: 10px; margin-bottom: 5px; border-left: solid 2px $tmp_color";
+	?>
+	@foreach ($tmp_msg_above_msg as $tmp_msg)
+		<div style="{{ $tmp_style }}">
+			{{ $tmp_msg }}
+		</div>
+	@endforeach
+	<?php
+		// as this shall not be shown on later screens: remove from session
+		// we could use Session::flash for this behavior – but this supports no arrays…
+		Session::forget($tmp_msg_above_key);
+	?>
+	@DivClose()
+@endforeach

--- a/resources/views/Generic/above_infos.blade.php
+++ b/resources/views/Generic/above_infos.blade.php
@@ -10,6 +10,8 @@
 	'tmp_error_above_relations',
 	];
 
+$tmp_msg_above_shown = False;
+
 $tmp_msg_above = [];
 foreach ($tmp_msg_above_keys as $tmp_msg_above_key) {
 	if ((Session::has($tmp_msg_above_key)) && (Str::endswith($tmp_msg_above_key, $blade_type))) {
@@ -43,6 +45,7 @@ foreach ($tmp_msg_above_keys as $tmp_msg_above_key) {
 			$tmp_color = '#aaaaaa';
 		}
 		$tmp_style = "font-weight: bold; padding-top: 0px; padding-left: 10px; margin-bottom: 5px; border-left: solid 2px $tmp_color";
+		$tmp_msg_above_shown = True;
 	?>
 	@foreach ($tmp_msg_above_msg as $tmp_msg)
 		<div style="{{ $tmp_style }}">
@@ -56,3 +59,9 @@ foreach ($tmp_msg_above_keys as $tmp_msg_above_key) {
 	?>
 	@DivClose()
 @endforeach
+
+@if ($tmp_msg_above)
+	@DivOpen(12)
+		&nbsp;
+	@DivClose()
+@endif

--- a/resources/views/Generic/form.blade.php
+++ b/resources/views/Generic/form.blade.php
@@ -5,6 +5,10 @@
 
 --}}
 
+<?php
+	$blade_type = 'form';
+?>
+
 {{-- Error Message --}}
 <?php $col = \Acme\Html\FormBuilder::get_layout_form_col_md()['label'] ?>
 @DivOpen(12)
@@ -15,31 +19,7 @@
 @DivClose()
 
 
-{{-- man can use the session key “tmp_info_above_form” to show additional data above the form for one screen --}}
-{{-- simply use Session::push('tmp_info_above_form', 'your additional data') in your observers or where you want --}}
-@if (Session::has('tmp_info_above_form'))
-	@DivOpen(12)
-	<?php
-		$tmp_info_above_form = Session::get('tmp_info_above_form');
-
-		// for better handling: transform strings to array (containing one element)
-		if (is_string($tmp_info_above_form)) {
-			$tmp_info_above_form = [$tmp_info_above_form];
-		};
-	?>
-	@foreach($tmp_info_above_form as $info)
-		<div style="font-weight: bold; padding-top: 0px; padding-left: 10px; margin-bottom: 5px; border-left: solid 2px #ffaaaa">
-			{{ $info }}
-		</div>
-	@endforeach
-	<br>
-	<?php
-		// as this shall not be shown on later screens: remove from session
-		// we could use Session::flash for this behavior – but this supports no arrays…
-		Session::forget('tmp_info_above_form'); ?>
-	@DivClose()
-@endif
-
+@include('Generic.above_infos')
 
 @foreach($form_fields as $fields)
 	{{ $fields['html'] }}

--- a/resources/views/Generic/index.blade.php
+++ b/resources/views/Generic/index.blade.php
@@ -11,6 +11,10 @@
 
 --}}
 
+<?php
+	$blade_type = 'index_list';
+?>
+
 @extends ('Layout.split84-nopanel')
 
 @section('content_top')
@@ -51,31 +55,7 @@
 			@endif
 	@DivClose()
 
-
-	{{-- man can use the session key “tmp_info_above_index_list” to show additional data above the form for one screen --}}
-	{{-- simply use Session::push('tmp_info_above_index_list', 'your additional data') in your observers or where you want --}}
-	@if (Session::has('tmp_info_above_index_list'))
-		@DivOpen(12)
-		<?php
-			$tmp_info_above_index_list = Session::get('tmp_info_above_index_list');
-
-			// for better handling: transform strings to array (containing one element)
-			if (is_string($tmp_info_above_index_list)) {
-				$tmp_info_above_index_list = [$tmp_info_above_index_list];
-			};
-		?>
-		@foreach($tmp_info_above_index_list as $info)
-			<div style="font-weight: bold; padding-top: 0px; padding-left: 10px; margin-bottom: 5px; border-left: solid 2px #ffaaaa">
-				{{ $info }}
-			</div>
-		@endforeach
-		<br>
-		<?php
-			// as this shall not be shown on later screens: remove from session
-			// we could use Session::flash for this behavior – but this supports no arrays…
-			Session::forget('tmp_info_above_index_list'); ?>
-		@DivClose()
-	@endif
+	@include('Generic.above_infos')
 
 	<!-- database entries inside a form with checkboxes to be able to delete one or more entries -->
 	@DivOpen(12)

--- a/resources/views/Generic/relation.blade.php
+++ b/resources/views/Generic/relation.blade.php
@@ -11,6 +11,7 @@ Relation Blade is used inside a Panel Element to display relational class object
 
 <?php
 	$route = $class; // for better reading / understanding
+	$blade_type = 'relations';
 ?>
 
 
@@ -22,31 +23,7 @@ Relation Blade is used inside a Panel Element to display relational class object
 @endif
 
 
-{{-- man can use the session key “tmp_info_above_relations” to show additional data above the form for one screen --}}
-{{-- simply use Session::push('tmp_info_above_relations', 'your additional data') in your observers or where you want --}}
-@if (Session::has('tmp_info_above_relations'))
-	@DivOpen(12)
-	<?php
-		$tmp_info_above_relations = Session::get('tmp_info_above_relations');
-
-		// for better handling: transform strings to array (containing one element)
-		if (is_string($tmp_info_above_relations)) {
-			$tmp_info_above_relations = [$tmp_info_above_relations];
-		};
-	?>
-	@foreach($tmp_info_above_relations as $info)
-		<div style="font-weight: bold; padding-top: 0px; padding-left: 10px; margin-bottom: 5px; border-left: solid 2px #ffaaaa">
-			{{ $info }}
-		</div>
-	@endforeach
-	<br>
-	<?php
-		// as this shall not be shown on later screens: remove from session
-		// we could use Session::flash for this behavior – but this supports no arrays…
-		Session::forget('tmp_info_above_relations'); ?>
-	@DivClose()
-@endif
-
+@include('Generic.above_infos')
 
 <!-- Create Button: (With hidden add fields if required) -->
 @if (!isset($options['hide_create_button']))


### PR DESCRIPTION
Initial problem: Impossible to delete Phonenumber because of n:m relation with EnviaOrder – this crashed on trying to delete children.

Issue is fixed; I also added information about delete success/errors above relation/index. Therefore I extended and improved the code showing *tmp*above* from session variable.

Also there are some minor fixes and beautifications