### PR TITLE
Re-enabled processing of final orders having comments.

### DIFF
--- a/modules/ProvVoipEnvia/Entities/EnviaOrder.php
+++ b/modules/ProvVoipEnvia/Entities/EnviaOrder.php
@@ -144,7 +144,8 @@ class EnviaOrder extends \BaseModel {
 				'orderstatus' => 'Fehlgeschlagen, Details siehe Bemerkung',
 				'view_class' => 'danger',
 				'state_type' => 'failed',
-				'final' => True,
+				//'final' => True,      // according to documentation state is final – but comment changed in real life
+				'final' => False,
 			),
 			array(
 				'orderstatus_id' => 1015,
@@ -200,7 +201,8 @@ class EnviaOrder extends \BaseModel {
 				'orderstatus' => 'Portierungsablehnung, siehe Bemerkung',
 				'view_class' => 'danger',
 				'state_type' => 'failed',
-				'final' => True,
+				//'final' => True,      // according to documentation state is final – but comment changed in real life
+				'final' => False,
 			),
 			array(
 				'orderstatus_id' => 1039,


### PR DESCRIPTION
According to API documentation orderstate 1038 is final and will not
change anymore.
In production system this is not the case – we watched changes in
orderdate and comment. So I set the orderstates 1038 and 1014 (having
comments) to not final to get the latest updates.