### PR TITLE
Bugfix/showing only action needing enviaorders

### DIFF
--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -1058,6 +1058,7 @@ class BaseController extends Controller {
 		$edit_column_data = isset($dt_config['edit']) ? $dt_config['edit'] : [];
 		$filter_column_data = isset($dt_config['filter']) ? $dt_config['filter'] : [];
 		$eager_loading_tables = isset($dt_config['eager_loading']) ? $dt_config['eager_loading'] : [];
+		$additional_raw_where_clauses = isset($dt_config['where_clauses']) ? $dt_config['where_clauses'] : [];
 
 		// if no id Column is drawn, draw it to generate links with id
 		!array_has($header_fields, $dt_config['table'].'.id') ? array_push($header_fields, 'id') : null;
@@ -1071,6 +1072,11 @@ class BaseController extends Controller {
 				$first_column = substr(head($header_fields), strlen($dt_config["table"]) + 1);
 			else
 				$first_column = head($header_fields);
+		}
+
+		// apply additional where clauses
+		foreach ($additional_raw_where_clauses as $where_clause) {
+			$request_query = $request_query->whereRaw($where_clause);
 		}
 
 		$DT = Datatables::of($request_query);

--- a/resources/views/bootstrap/menu.blade.php
+++ b/resources/views/bootstrap/menu.blade.php
@@ -25,7 +25,7 @@
 				@if (\PPModule::is_active('provvoipenvia'))
 					{{-- count of user interaction needing EnviaOrders --}}
 					<li  class='m-t-10' style='font-size: 2em; font-weight: bold'>
-						<a href="{{route('EnviaOrder.index', ['show_filter' => 'action_needed'])}}" target="_self">
+						<a href="{{route('EnviaOrder.index', ['show_filter' => 'action_needed'])}}" target="_self" style="text-decoration: none">
 							@if (Modules\ProvVoipEnvia\Entities\EnviaOrder::get_user_interaction_needing_enviaorder_count() > 0)
 								<span style='color: #f00; text-decoration:none' title='{{ Modules\ProvVoipEnvia\Entities\EnviaOrder::get_user_interaction_needing_enviaorder_count() }} user interaction needing EnviaOrders'>✘
 								<sup>{{ Modules\ProvVoipEnvia\Entities\EnviaOrder::get_user_interaction_needing_enviaorder_count() }}</sup>


### PR DESCRIPTION
With introduction of datatables the filter for showing only user interaction needing envia TEL orders where out of order – e.g. clicking the “red numbered ✘” on page top showed all existing orders instead of the expected subset.

@cschra:
This is something you could not know/see/test without a proper set of EnviaOrders in your database. To fix this I had to add some code to BaseController::index_datatables_ajax(); this should not affect any models not using the new dt_config key.
Would you please check:
- that this does not break something
- if I there is a simpler/better/quicker solution (maybe hidden in the depths of datatables?)

Thank you.