### PR TITLE
No arguments given ⇒ EnviaOrder::create() created empty instances.

### DIFF
--- a/modules/ProvVoipEnvia/Entities/EnviaOrder.php
+++ b/modules/ProvVoipEnvia/Entities/EnviaOrder.php
@@ -221,9 +221,9 @@ class EnviaOrder extends \BaseModel {
 	 *
 	 * @author Patrick Reichel
 	 */
-	public function __construct() {
+	public function __construct($attributes = array()) {
 
-		parent::__construct();
+		parent::__construct($attributes);
 
 		// preserve currently set show filter for later use in datatable calls
 		$this->store_index_show_filter_in_session();


### PR DESCRIPTION
Also changed in production system.